### PR TITLE
authenticate and seal firmware images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ add_executable(picowota
 	main.c
 	tcp_comm.c
 	dhcpserver/dhcpserver.c
+	${PICO_SDK_PATH}/lib/mbedtls/library/sha256.c
+	${PICO_SDK_PATH}/lib/mbedtls/library/platform_util.c
+	${PICO_SDK_PATH}/lib/mbedtls/library/constant_time.c
 )
 
 function(target_cl_options option)
@@ -54,7 +57,9 @@ pico_add_extra_outputs(picowota)
 
 target_include_directories(picowota PRIVATE
 	${CMAKE_CURRENT_LIST_DIR} # Needed so that lwip can find lwipopts.h
-	${CMAKE_CURRENT_LIST_DIR}/dhcpserver)
+	${CMAKE_CURRENT_LIST_DIR}/dhcpserver
+	${PICO_SDK_PATH}/lib/mbedtls/include
+)
 
 pico_enable_stdio_usb(picowota 1)
 
@@ -89,6 +94,7 @@ endfunction()
 picowota_retrieve_variable(PICOWOTA_WIFI_SSID false)
 picowota_retrieve_variable(PICOWOTA_WIFI_PASS true)
 picowota_retrieve_variable(PICOWOTA_WIFI_AP false)
+picowota_retrieve_variable(PICOWOTA_FLASH_KEY true)
 
 if ((NOT PICOWOTA_WIFI_SSID) OR (NOT PICOWOTA_WIFI_PASS))
         message(FATAL_ERROR
@@ -113,6 +119,8 @@ function(picowota_build_standalone NAME)
 	pico_set_linker_script(${NAME} ${PICOWOTA_SRC_DIR}/standalone.ld)
 	pico_add_bin_output(${NAME})
 endfunction()
+
+pico_set_linker_script(picowota ${CMAKE_CURRENT_LIST_DIR}/bootloader.ld)
 
 # Provide a helper to build a combined target
 # The build process is roughly:

--- a/bootloader.ld
+++ b/bootloader.ld
@@ -63,16 +63,38 @@ SECTIONS
        launches only, to perform proper flash setup.
     */
 
-    .flashtext : {
+    .text : {
         __logical_binary_start = .;
         KEEP (*(.vectors))
         KEEP (*(.binary_info_header))
         __binary_info_header_end = .;
         KEEP (*(.reset))
-    }
+        /* TODO revisit this now memset/memcpy/float in ROM */
+        /* bit of a hack right now to exclude all floating point and time critical (e.g. memset, memcpy) code from
+         * FLASH ... we will include any thing excluded here in .data below by default */
+        *(.init)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a:) .text*)
+        *(.fini)
+        /* Pull all c'tors into .text */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+        /* Followed by destructors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
 
     .rodata : {
-        /* segments not marked as .flashdata are instead pulled into .data (in RAM) to avoid accidental flash accesses */
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a:) .rodata*)
+        . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
     } > FLASH
@@ -100,35 +122,9 @@ SECTIONS
     __binary_info_end = .;
     . = ALIGN(4);
 
-    /* Vector table goes first in RAM, to avoid large alignment hole */
-   .ram_vector_table (COPY): {
+   .ram_vector_table (NOLOAD): {
         *(.ram_vector_table)
     } > RAM
-
-    .text : {
-        __ram_text_start__ = .;
-        *(.init)
-        *(.text*)
-        *(.fini)
-        /* Pull all c'tors into .text */
-        *crtbegin.o(.ctors)
-        *crtbegin?.o(.ctors)
-        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
-        *(SORT(.ctors.*))
-        *(.ctors)
-        /* Followed by destructors */
-        *crtbegin.o(.dtors)
-        *crtbegin?.o(.dtors)
-        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
-        *(SORT(.dtors.*))
-        *(.dtors)
-
-        *(.eh_frame*)
-        . = ALIGN(4);
-        __ram_text_end__ = .;
-    } > RAM AT> FLASH
-    __ram_text_source__ = LOADADDR(.text);
-
 
     .data : {
         __data_start__ = .;
@@ -136,6 +132,8 @@ SECTIONS
 
         *(.time_critical*)
 
+        /* remaining .text and .rodata; i.e. stuff we exclude above because we want it in RAM */
+        *(.text*)
         . = ALIGN(4);
         *(.rodata*)
         . = ALIGN(4);
@@ -177,10 +175,10 @@ SECTIONS
         /* All data end */
         __data_end__ = .;
     } > RAM AT> FLASH
-    /* __etext is the name of the .data init source pointer (...) */
+    /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
 
-    .uninitialized_data (COPY): {
+    .uninitialized_data (NOLOAD): {
         . = ALIGN(4);
         *(.uninitialized_data*)
     } > RAM
@@ -211,11 +209,11 @@ SECTIONS
         __bss_end__ = .;
     } > RAM
 
-    .heap (COPY):
+    .heap (NOLOAD):
     {
         __end__ = .;
         end = __end__;
-        *(.heap*)
+        KEEP(*(.heap*))
         __HeapLimit = .;
     } > RAM
 
@@ -228,18 +226,20 @@ SECTIONS
     /* by default we put core 0 stack at the end of scratch Y, so that if core 1
      * stack is not used then all of SCRATCH_X is free.
      */
-    .stack1_dummy (COPY):
+    .stack1_dummy (NOLOAD):
     {
         *(.stack1*)
     } > SCRATCH_X
-    .stack_dummy (COPY):
+    .stack_dummy (NOLOAD):
     {
-        *(.stack*)
+        KEEP(*(.stack*))
     } > SCRATCH_Y
 
     .flash_end : {
-        __flash_binary_end = .;
+        PROVIDE(__flash_binary_end = .);
     } > FLASH
+    __wota_image_header_offset = ORIGIN(FLASH)+LENGTH(FLASH);
+    ASSERT( __flash_binary_end < __wota_image_header_offset, "Flash overflowed into image")
 
     /* stack limit is poorly named, but historically is maximum heap ptr */
     __StackLimit = ORIGIN(RAM) + LENGTH(RAM);

--- a/standalone.ld
+++ b/standalone.ld
@@ -217,6 +217,10 @@ SECTIONS
         __flash_binary_end = .;
     } > FLASH
 
+    __wota_image_header_offset = ORIGIN(FLASH)+LENGTH(FLASH - 4k);
+    ASSERT( __flash_binary_end < __wota_image_header_offset, "Flash overflowed into image")
+
+
     /* stack limit is poorly named, but historically is maximum heap ptr */
     __StackLimit = ORIGIN(RAM) + LENGTH(RAM);
     __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);


### PR DESCRIPTION
This resolves #6. The security model is as described in that issue:

- An unrelated attacker, that cannot observe "authorized" traffic cannot do anything
- A passive attacker, who can observe a connection, can obtain the uploaded firmware image, together with its authentication tag, but cannot create a new connection to picowota to upload the image.
- An active attacker, who can take over tcp connections still has no way to create new connection on their own. On an existing connection that they took over, they can erase flash, boot, but cannot use picowota to upload an unrelated firmware image. Only firmware images, where the attacker previously observed the upload can be replayed.

To use these changes, a corresponding change in https://github.com/usedbytes/serial-flash is required. That I can prepare a PR for, if this change is wanted.