### PR TITLE
CMakeLists.txt: fix dependencies to allow make -j

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,14 +137,14 @@ function(picowota_build_combined NAME)
 	pico_set_linker_script(picowota ${PICOWOTA_SRC_DIR}/bootloader_shell.ld)
 
 	# TODO: The hard-coded address here is a bit nasty
-	add_custom_target(${NAME}_hdr DEPENDS ${APP_BIN})
-	add_custom_command(TARGET ${NAME}_hdr DEPENDS ${APP_BIN}
+	add_custom_target(${NAME}_hdr DEPENDS ${NAME})
+	add_custom_command(TARGET ${NAME}_hdr DEPENDS ${NAME}
 		COMMAND ${PICOWOTA_SRC_DIR}/gen_imghdr.py -a 0x1005B000 ${APP_BIN} ${APP_HDR_BIN}
 	)
 
 	add_custom_target(${COMBINED} ALL)
-	add_dependencies(${COMBINED} picowota ${NAME}_hdr ${NAME})
-	add_custom_command(TARGET ${COMBINED} DEPENDS ${APP_HDR_BIN} ${APP_BIN}
+	add_dependencies(${COMBINED} picowota ${NAME}_hdr)
+	add_custom_command(TARGET ${COMBINED} DEPENDS ${NAME}_hdr
 		COMMAND ${CMAKE_OBJCOPY}
 			--update-section .app_hdr=${APP_HDR_BIN}
 			--update-section .app_bin=${APP_BIN} ${PICOWOTA_BIN_DIR}/picowota.elf ${COMBINED}.elf


### PR DESCRIPTION
As `${APP_BIN}` and `${APP_HDR_BIN}` are not true targets, the dependency on them effectively only required the .bin files to be present.

When building with `make -j`, this led to the situation that the target `${NAME}_hdr` finished *before* compiling the project, in case there were .bin files left from previous builds, leading to `${NAME}_hdr.bin` files containing invalid CRCs.

Setting the dependencies on `${NAME}` fixes this issue. The reasoning is that if target `${NAME}` is built, `${APP_BIN}` should have been generated. There is no need to depend on both `${NAME}` and `${NAME}_hdr`, as `${NAME}_hdr` already depends on `${NAME}`.