### PR TITLE
Improve build process by looking up address instead of hardcoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,10 +136,9 @@ function(picowota_build_combined NAME)
 	# Build the bootloader with the sections to fill in
 	pico_set_linker_script(picowota ${PICOWOTA_SRC_DIR}/bootloader_shell.ld)
 
-	# TODO: The hard-coded address here is a bit nasty
 	add_custom_target(${NAME}_hdr DEPENDS ${APP_BIN})
-	add_custom_command(TARGET ${NAME}_hdr DEPENDS ${APP_BIN}
-		COMMAND ${PICOWOTA_SRC_DIR}/gen_imghdr.py -a 0x1005B000 ${APP_BIN} ${APP_HDR_BIN}
+	add_custom_command(TARGET ${NAME}_hdr DEPENDS ${APP_BIN} picowota
+		COMMAND ${PICOWOTA_SRC_DIR}/gen_imghdr.py --map ${PICOWOTA_BIN_DIR}/picowota.elf.map --section .app_bin ${APP_BIN} ${APP_HDR_BIN}
 	)
 
 	add_custom_target(${COMBINED} ALL)

--- a/gen_imghdr.py
+++ b/gen_imghdr.py
@@ -39,6 +39,9 @@ parser.add_argument("ifile", help="Input application binary (binary)")
 parser.add_argument("ofile", help="Output header file (binary)")
 parser.add_argument("-a", "--addr", help="Load address of the application image",
                     type=any_int, default=0x10004000)
+parser.add_argument("-m", "--map", help="Map file to scan for application image section")
+parser.add_argument("-s", "--section", help="Section name to look for in map file",
+                    default=".app_bin")
 args = parser.parse_args()
 
 try:
@@ -46,7 +49,22 @@ try:
 except:
     sys.exit("Could not open input file '{}'".format(args.ifile))
 
-vtor = args.addr
+if args.map:
+    vtor = None
+    with open(args.map) as mapfile:
+        for line in mapfile:
+            if line.startswith(args.section):
+                parts = line.split()
+                if len(parts)>1:
+                    vtor = int(parts[1],0)
+                    print('found address 0x%x for %s in %s'%(vtor,args.section,args.map))
+                    break
+
+    if vtor is None:
+        sys.exit("Could not find section {} in {}".format(args.section,args.map))
+else:
+    vtor = args.addr
+
 size = len(idata)
 crc = binascii.crc32(idata)
 


### PR DESCRIPTION
The image address can be extracted from the map file that is generated in the build process of picowota. A feature to do this is added to the existing python script.