### PR TITLE
Add UART debugging option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,13 @@ target_include_directories(picowota PRIVATE
 	${CMAKE_CURRENT_LIST_DIR} # Needed so that lwip can find lwipopts.h
 	${CMAKE_CURRENT_LIST_DIR}/dhcpserver)
 
-pico_enable_stdio_usb(picowota 1)
+if(${PICOWOTA_DEBUG_UART})
+  pico_enable_stdio_usb(picowota 0)
+  pico_enable_stdio_uart(picowota 1)
+  target_compile_definitions(picowota PRIVATE DEBUG_UART)
+else()
+  pico_enable_stdio_usb(picowota 1)
+endif()
 
 add_subdirectory(picowota_reboot)
 

--- a/main.c
+++ b/main.c
@@ -30,7 +30,12 @@
 
 #include "picowota/reboot.h"
 
-#ifdef DEBUG
+#if defined(DEBUG_UART)
+#include <stdio.h>
+#include "pico/stdio_uart.h"
+#define DBG_PRINTF_INIT() stdio_uart_init()
+#define DBG_PRINTF(...) printf(__VA_ARGS__)
+#elif defined(DEBUG)
 #include <stdio.h>
 #include "pico/stdio_usb.h"
 #define DBG_PRINTF_INIT() stdio_usb_init()


### PR DESCRIPTION
Modify CMakeLists to accept new var PICOWOTA_DEBUG_UART. Must set var to true to enable.
Modify main.c to accept new compile time definition DEBUG_UART Searched for "DEBUG_UART" conflicts in pico-sdk and found none. (some close matches, but nothing exact)

Tested both usb debug and uart debug with freshly flashed bootloaders.